### PR TITLE
Fix rockspec source and missing init.lua in rock

### DIFF
--- a/st-0.0-2.rockspec
+++ b/st-0.0-2.rockspec
@@ -1,7 +1,8 @@
 package = "st"
-version = "0.0-1"
+version = "0.0-2"
 source = {
-  url = "https://github.com/SmartThingsCommunity/st.lua"
+  url = "git+https://github.com/SmartThingsCommunity/st.lua.git",
+  tag = "v0.0-2"
 }
 description = {
   summary = "",


### PR DESCRIPTION
Following up on [this issue](https://github.com/SmartThingsCommunity/st.lua/issues/1#issuecomment-1622562832), I believe there was simply an issue with the url being returned, and changing it slightly should fix the noted issue. I have uploaded a 0.0-2 tag already including these changes.

I have tested this locally and now receive the correct data in the rock.
[ ]([https://smartthings.atlassian.net/browse/CHAD-11266])